### PR TITLE
更新@minecraft/common的翻译

### DIFF
--- a/translate-pieces/common/classes/EngineError.d.ts
+++ b/translate-pieces/common/classes/EngineError.d.ts
@@ -1,4 +1,6 @@
 /**
+ * 表示在处理函数时引擎中发生的底层错误。
+ * 
  * Specifies an underlying error in the engine in processing a
  * function.
  */

--- a/translate-pieces/common/classes/InvalidArgumentError.d.ts
+++ b/translate-pieces/common/classes/InvalidArgumentError.d.ts
@@ -1,4 +1,6 @@
 /**
+ * 表示指定传递给方法的参数不正确或不被允许。
+ * 
  * Specifies that a passed-in argument to a method is not
  * correct or allowed.
  */


### PR DESCRIPTION
这是我第一次参与这个项目的翻译，所以内容会比较少（

翻译了@minecraft/common中所有**有英文注释**的类，除此之外，关于一些没有英文注释的类/方法/变量，不知道该如何处理，例如 common 里面的`PropertyOutOfBoundsError`：

```ts
export class PropertyOutOfBoundsError extends Error {
    private constructor();
    maxValue: number;
    minValue: number;
    value: number;
}
```

如果这个 pr 能被通过，我在未来会尽可能多的参与到这个项目的翻译中来！