### PR TITLE
Update Block.d.ts 中的译名标准问题

### DIFF
--- a/translate-pieces/server/classes/Block.d.ts
+++ b/translate-pieces/server/classes/Block.d.ts
@@ -60,7 +60,7 @@ export class Block {
      * @beta
      * @remarks
      * 如果该块是实心且不可通行的，则返回 true
-     * -（例如，鹅卵石块和钻石块是实心的，而梯子块和栅栏块则不是）。
+     * -（例如，圆石和钻石块是实心方块，而梯子和栅栏则不是）。
      *
      * Returns true if this block is solid and impassible - (e.g.,
      * a cobblestone block and a diamond block are solid, while a


### PR DESCRIPTION
isLiquid 函数中存在描述“鹅卵石块和钻石块是实心的，而梯子块和栅栏块则不是”。其中，“鹅卵石”为台湾标准译名，“钻石块”为大陆标准译名，二者不应在同一中文语境（此处为简体中文）中混译。同时，“栅栏块”和“梯子块”中“块”翻译自英文原文“block”，在中文中硬加“块”字会使文本读起来生硬，此处没有必要强调“块”。