### PR TITLE
翻译与补充 server-ui MessageForm 相关类

### DIFF
--- a/translate-pieces/server-ui/classes/FormResponse.d.ts
+++ b/translate-pieces/server-ui/classes/FormResponse.d.ts
@@ -1,18 +1,24 @@
 /* IMPORT */ import { FormCancelationReason } from '..';
 
 /**
+ * 表单结果的基础类型。
+ *
  * Base type for a form response.
  */
 export class FormResponse {
     private constructor();
     /**
      * @remarks
+     * 表单被取消的附加原因。
+     *
      * Contains additional details as to why a form was canceled.
      *
      */
     readonly cancelationReason?: FormCancelationReason;
     /**
      * @remarks
+     * 若为 `true`，则表单由玩家取消（例如点击了关闭按钮）。
+     *
      * If true, the form was canceled by the player (e.g., they
      * selected the pop-up X close button).
      *

--- a/translate-pieces/server-ui/classes/MessageFormData.d.ts
+++ b/translate-pieces/server-ui/classes/MessageFormData.d.ts
@@ -3,6 +3,8 @@
 /* IMPORT */ import { MessageFormResponse } from '..';
 
 /**
+ * 构建简易的双按钮模态对话框。
+ *
  * Builds a simple two-button modal dialog.
  * @seeExample showBasicMessageForm.ts
  * @seeExample showTranslatedMessageForm.ts
@@ -10,26 +12,40 @@
 export class MessageFormData {
     /**
      * @remarks
+     * 设定模态表单的主体文本。
+     *
      * Method that sets the body text for the modal form.
      *
+     * @param bodyText
+     * 主体文本内容。
      */
     body(bodyText: RawMessage | string): MessageFormData;
     /**
      * @remarks
+     * 设定对话框第一个按钮的文本。
+     *
      * Method that sets the text for the first button of the
      * dialog.
      *
+     * @param text
+     * 按钮文本内容。
      */
     button1(text: RawMessage | string): MessageFormData;
     /**
      * @remarks
+     * 设定对话框第二个按钮的文本。
+     *
      * This method sets the text for the second button on the
      * dialog.
      *
+     * @param text
+     * 按钮文本内容。
      */
     button2(text: RawMessage | string): MessageFormData;
     /**
      * @remarks
+     * 创建并展示此模态弹出式表单，玩家点击确定或取消按钮后异步返回。
+     *
      * Creates and shows this modal popup form. Returns
      * asynchronously when the player confirms or cancels the
      * dialog.
@@ -37,8 +53,10 @@ export class MessageFormData {
      * @worldMutation
      *
      * @param player
+     * 要展示对话框的玩家。
+     *
      * Player to show this dialog to.
-     * @throws This function can throw errors.
+     * @throws 此函数可能抛出错误。
      *
      * {@link EngineError}
      *
@@ -49,8 +67,12 @@ export class MessageFormData {
     show(player: Player): Promise<MessageFormResponse>;
     /**
      * @remarks
+     * 设定对话框标题。
+     *
      * This builder method sets the title for the modal dialog.
      *
+     * @param titleText
+     * 标题文本内容。
      */
     title(titleText: RawMessage | string): MessageFormData;
 }

--- a/translate-pieces/server-ui/classes/MessageFormData.d.ts
+++ b/translate-pieces/server-ui/classes/MessageFormData.d.ts
@@ -44,7 +44,7 @@ export class MessageFormData {
     button2(text: RawMessage | string): MessageFormData;
     /**
      * @remarks
-     * 创建并展示此模态弹出式表单，玩家点击确定或取消按钮后异步返回。
+     * 创建并展示此模态弹出式表单，玩家点击确定或取消按钮后异步返回。表单必须有内容，否则将展示创建失败的消息框；玩家的游戏界面不能被聊天屏幕等界面阻塞，否则将不会展示。
      *
      * Creates and shows this modal popup form. Returns
      * asynchronously when the player confirms or cancels the
@@ -56,13 +56,12 @@ export class MessageFormData {
      * 要展示对话框的玩家。
      *
      * Player to show this dialog to.
-     * @throws 此函数可能抛出错误。
+     * @throws 
+     * 如果发生底层错误，将抛出 {@link EngineError}。
      *
-     * {@link EngineError}
+     * 如果 `player` 传入的玩家当前不在世界中，将抛出 {@link InvalidEntityError}。
      *
-     * {@link InvalidEntityError}
-     *
-     * {@link RawMessageError}
+     * 如果表单中存在无法正常解析的文本组件，将抛出 {@link RawMessageError}。
      */
     show(player: Player): Promise<MessageFormResponse>;
     /**

--- a/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
+++ b/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
@@ -13,7 +13,7 @@ export class MessageFormResponse extends FormResponse {
     private constructor();
     /**
      * @remarks
-     * 按下的按钮的索引。
+     * 按下的按钮的索引（0 或 1）。
      *
      * Returns the index of the button that was pushed.
      *

--- a/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
+++ b/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
@@ -1,6 +1,8 @@
 /* IMPORT */ import { FormResponse } from '..';
 
 /**
+ * 获取信息表单的结果。
+ *
  * Returns data about the player results from a modal message
  * form.
  * @seeExample showBasicMessageForm.ts
@@ -11,6 +13,8 @@ export class MessageFormResponse extends FormResponse {
     private constructor();
     /**
      * @remarks
+     * 按下的按钮的索引。
+     *
      * Returns the index of the button that was pushed.
      *
      */

--- a/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
+++ b/translate-pieces/server-ui/classes/MessageFormResponse.d.ts
@@ -1,7 +1,7 @@
 /* IMPORT */ import { FormResponse } from '..';
 
 /**
- * 获取信息表单的结果。
+ * 获取信息表单（Message Form）的结果。
  *
  * Returns data about the player results from a modal message
  * form.


### PR DESCRIPTION
模块中有时将 form 和 dialog 混用，此处为了避免冲突，选择了尽可能尊重原文。由于 2.1.0-beta 有个 MessageBox 信息框，所以将本次翻译的原来旧的“信息框” MessageForm 翻译为“信息表单”以作区分。